### PR TITLE
Avoid NPE when on analysis is present

### DIFF
--- a/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/FileProvenanceConsumer.java
+++ b/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/FileProvenanceConsumer.java
@@ -64,6 +64,9 @@ public interface FileProvenanceConsumer {
                 limsInformation.put(new ExternalId(key.getProvider(), key.getId()), match.get());
               }
             }
+            if (workflowRun.getAnalysis() == null) {
+              return;
+            }
             for (final var analysis : workflowRun.getAnalysis()) {
               for (final var key : analysis.getExternalKeys()) {
                 final var lims =


### PR DESCRIPTION
Don't throw an null pointer exception when the workflow run has no associated
analysis.