### PR TITLE
Gp 3210 aggregate skip status

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
+++ b/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
@@ -397,8 +397,17 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
                 })
             .orElse("NoIndex"));
     cs.add(""); // IUS SWIDs
-    cs.add(record.workflow().getExternalKeys().stream()
-            .filter(key -> key.getId().equals(record.lims().getProvenanceId())) // Get external keys with same ID as LIMS provenance ID, aka the run_lane_libraryID string
+    cs.add(
+        record.workflow().getExternalKeys().stream()
+            .filter(
+                key ->
+                    key.getId()
+                        .equals(
+                            record
+                                .lims()
+                                .getProvenanceId())) // Get external keys with same ID as LIMS
+            // provenance ID, aka the run_lane_libraryID
+            // string
             .map(key -> "shesmu-sha1=" + key.getVersions().get("shesmu-sha1"))
             .collect(Collectors.joining())); // IUS Attributes
 

--- a/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
+++ b/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
@@ -177,7 +177,7 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
   }
 
   @Override
-  public void file(boolean stale, ProvenanceRecord<LimsProvenance> record) {
+  public void file(boolean stale, boolean skip, ProvenanceRecord<LimsProvenance> record) {
 
     final var cs = new ArrayList<String>();
     final var sampleAttributes =
@@ -446,8 +446,8 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
     cs.add(Long.toString(record.record().getSize()));
     cs.add(""); // File description
 
-    cs.add("false"); // Path skip
-    cs.add("false"); // Skip
+    cs.add(Boolean.toString(skip)); // Path skip
+    cs.add(Boolean.toString(skip)); // Skip
 
     cs.add(stale ? "STALE" : "OKAY");
     cs.add(""); // Status reason

--- a/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/FileProvenanceConsumer.java
+++ b/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/FileProvenanceConsumer.java
@@ -85,24 +85,25 @@ public interface FileProvenanceConsumer {
 
             // if any of the external ids are skipped, then all of provenance records from
             // this workflowRun should be skipped too
-            final var skip = output.stream().anyMatch(
-                rec -> {
-                  return rec.<Boolean>apply(
-                          new ProvenanceRecord.Mapper<>(SampleProvenance.class) {
-                            @Override
-                            protected Boolean apply(SampleProvenance lims) {
-                              return lims.getSkip();
-                            }
-                          },
-                          new ProvenanceRecord.Mapper<>(LaneProvenance.class) {
-                            @Override
-                            protected Boolean apply(LaneProvenance lims) {
-                              return lims.getSkip();
-                            }
-                          })
-                      .orElse(Boolean.FALSE);
-                }
-            );
+            final var skip =
+                output.stream()
+                    .anyMatch(
+                        rec -> {
+                          return rec.<Boolean>apply(
+                                  new ProvenanceRecord.Mapper<>(SampleProvenance.class) {
+                                    @Override
+                                    protected Boolean apply(SampleProvenance lims) {
+                                      return lims.getSkip();
+                                    }
+                                  },
+                                  new ProvenanceRecord.Mapper<>(LaneProvenance.class) {
+                                    @Override
+                                    protected Boolean apply(LaneProvenance lims) {
+                                      return lims.getSkip();
+                                    }
+                                  })
+                              .orElse(Boolean.FALSE);
+                        });
 
             final var s = stale;
             output.forEach(file -> consumer.file(s, skip, file));
@@ -125,8 +126,8 @@ public interface FileProvenanceConsumer {
    *
    * @param stale whether the data is stale (a Pinery version mismatch occurred for this workflow
    *     run)
-   * @param skip  whether the data should not be used due to some reason (e.g. the lims record was
-   *              marked as QC failed in Pinery)
+   * @param skip whether the data should not be used due to some reason (e.g. the lims record was
+   *     marked as QC failed in Pinery)
    * @param record the joined record
    */
   void file(boolean stale, boolean skip, ProvenanceRecord<LimsProvenance> record);

--- a/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/vidarr/VidarrWorkflowRunSource.java
+++ b/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/vidarr/VidarrWorkflowRunSource.java
@@ -67,6 +67,7 @@ public final class VidarrWorkflowRunSource
     return IncrementalJoinSource.accumulating(
         new VidarrWorkflowRunSource(instanceName, baseUrl, versionTypes));
   }
+
   private final String baseUrl;
   private long epoch;
   private final String instanceName;

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>ca.on.oicr.gsi.cerberus</groupId>
   <artifactId>cerberus</artifactId>
@@ -156,6 +157,25 @@
           <target>14</target>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.cosium.code</groupId>
+        <artifactId>git-code-format-maven-plugin</artifactId>
+        <version>3.3</version>
+        <executions>
+          <execution>
+            <id>install-formatter-hook</id>
+            <goals>
+              <goal>install-hooks</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-code-format</id>
+            <goals>
+              <goal>validate-code-format</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
For example, if a workflow run is associated with sample 1 and sample 2
and produces one output file (file1), provenance records from this
workflow run will look like:
sample1 --> file1
sample2 --> file1

If sample 1 is "skipped" (e.g. QC is set to failed in MISO), provenance
record outputs from this workflow run should be marked as skipped, for
example:
sample1, skip=true --> file1
sample2, skip=true --> file1