### PR TITLE
Export the current external id version in tsv report

### DIFF
--- a/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
+++ b/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
@@ -464,9 +464,12 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
     cs.add("");
     // here we mangle the "Provider" field to look more similar to the current FPR provider field.
     // TODO: Ideally a new field of "format revision" would be added in a future update of FPR.
-    cs.add(record.provider() + "-v" + record.formatRevision());
-    cs.add(record.lims().getProvenanceId());
-    cs.add(record.lims().getVersion());
+    cs.add(
+        record.currentExternalIdVersion().getProvider()
+            + "-v"
+            + record.currentExternalIdVersion().getFormatRevision());
+    cs.add(record.currentExternalIdVersion().getId());
+    cs.add(record.currentExternalIdVersion().getVersion());
     cs.add(record.lims().getLastModified().format(LIMS_DATE_TIME_FORMATTER));
     try {
       output.printRecord(cs);

--- a/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/ProvenanceRecord.java
+++ b/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/fileprovenance/ProvenanceRecord.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.cerberus.fileprovenance;
 
+import ca.on.oicr.gsi.cerberus.pinery.ExternalIdVersion;
 import ca.on.oicr.gsi.provenance.model.LimsProvenance;
 import ca.on.oicr.gsi.vidarr.api.ExternalId;
 import ca.on.oicr.gsi.vidarr.api.ExternalKey;
@@ -47,6 +48,7 @@ public final class ProvenanceRecord<T extends LimsProvenance> {
   private final int formatRevision;
   private final T lims;
   private final String provider;
+  private final ExternalIdVersion currentExternalIdVersion;
   private final ProvenanceAnalysisRecord<ExternalId> record;
   private final ProvenanceWorkflowRun<ExternalKey> workflow;
 
@@ -54,6 +56,7 @@ public final class ProvenanceRecord<T extends LimsProvenance> {
       String provider,
       int formatRevision,
       T lims,
+      ExternalIdVersion currentExternalIdVersion,
       ProvenanceWorkflowRun<ExternalKey> workflow,
       ProvenanceAnalysisRecord<ExternalId> record) {
     this.formatRevision = formatRevision;
@@ -61,6 +64,7 @@ public final class ProvenanceRecord<T extends LimsProvenance> {
     this.workflow = workflow;
     this.record = record;
     this.provider = provider;
+    this.currentExternalIdVersion = currentExternalIdVersion;
   }
 
   /**
@@ -86,7 +90,13 @@ public final class ProvenanceRecord<T extends LimsProvenance> {
   public <S extends T> boolean asSubtype(Class<S> clazz, Consumer<ProvenanceRecord<S>> consumer) {
     if (clazz.isInstance(lims)) {
       consumer.accept(
-          new ProvenanceRecord<>(provider, formatRevision, clazz.cast(lims), workflow, record));
+          new ProvenanceRecord<>(
+              provider,
+              formatRevision,
+              clazz.cast(lims),
+              currentExternalIdVersion,
+              workflow,
+              record));
       return true;
     } else {
       return false;
@@ -103,6 +113,10 @@ public final class ProvenanceRecord<T extends LimsProvenance> {
 
   public String provider() {
     return provider;
+  }
+
+  public ExternalIdVersion currentExternalIdVersion() {
+    return currentExternalIdVersion;
   }
 
   public ProvenanceAnalysisRecord<ExternalId> record() {

--- a/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/pinery/ExternalIdVersion.java
+++ b/cerberus-core/src/main/java/ca/on/oicr/gsi/cerberus/pinery/ExternalIdVersion.java
@@ -1,0 +1,37 @@
+package ca.on.oicr.gsi.cerberus.pinery;
+
+public class ExternalIdVersion implements Comparable<ExternalIdVersion> {
+
+  private final String provider;
+  private final String id;
+  private final int formatRevision;
+  private final String version;
+
+  public ExternalIdVersion(String provider, String id, int formatRevision, String version) {
+    this.provider = provider;
+    this.id = id;
+    this.formatRevision = formatRevision;
+    this.version = version;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public int getFormatRevision() {
+    return formatRevision;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public int compareTo(ExternalIdVersion other) {
+    return Integer.compare(formatRevision, other.formatRevision);
+  }
+}


### PR DESCRIPTION
When needing to compare the current external id version associated with
an analysis record to the latest/newest external id version being
returned from a provider, we need to know what the current/previous
version is.

Previously in the tsv report, the latest/newest external id version was
returned. This change only modifies the tsv report to return the current
version. We want to return the latest version to shesmu so that it can
update vidarr's external id version if shesmu calculates a matching
signature (pinery-hash autoupdating feature).