### PR TITLE
Use Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 14
+        java-version: 17
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>14</source>
-          <target>14</target>
+          <source>17</source>
+          <target>17</target>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-core</artifactId>
-        <version>2.2.2.Final</version>
+        <version>2.3.3.Final</version>
       </dependency>
       <dependency>
         <groupId>ca.on.oicr.gsi.cerberus</groupId>


### PR DESCRIPTION
Time to modernize

Also upgrades Undertow (to resolve security alerts) to the version used by Vidarr, which we know is reliable.