### PR TITLE
[GP-4334] Vidarr now uses an arbitrary checksum

### DIFF
--- a/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
+++ b/cerberus-cli/src/main/java/ca/on/oicr/gsi/cerberus/cli/TabReportGenerator.java
@@ -93,7 +93,7 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
               "File SWID",
               "File Attributes",
               "File Path",
-              "File Md5sum",
+              "File Md5sum", // Technically, this can now include any type of checksum
               "File Size",
               "File Description",
               "Path Skip",
@@ -455,7 +455,7 @@ public final class TabReportGenerator implements FileProvenanceConsumer, AutoClo
     cs.add("vidarr:" + record.workflow().getInstanceName() + "/file/" + record.record().getId());
     cs.add(transformSimple(SANITISE_ATTRIBUTE, SANITISE_ATTRIBUTE, record.record().getLabels()));
     cs.add(SANITISE_FIELD.apply(record.record().getPath()));
-    cs.add(SANITISE_FIELD.apply(record.record().getMd5()));
+    cs.add(SANITISE_FIELD.apply(record.record().getChecksum()));
     cs.add(Long.toString(record.record().getSize()));
     cs.add(""); // File description
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>ca.on.oicr.gsi.vidarr</groupId>
         <artifactId>vidarr-pluginapi</artifactId>
-        <version>0.20.2-SNAPSHOT</version>
+        <version>0.21.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
       <dependency>
         <groupId>ca.on.oicr.gsi.vidarr</groupId>
         <artifactId>vidarr-pluginapi</artifactId>
-        <version>0.20.1</version>
+        <version>0.20.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
As per discussions in our private channel, the 'File Md5sum' column is keeping its name, and sometimes the content will be not be an md5sum. Users can switch to a more modern method of accessing file provenance information if they want the checksum type column which would provide context. 

Needs the pom version fixed before merge.